### PR TITLE
Potential fix for code scanning alert no. 124: Missing rate limiting

### DIFF
--- a/code/24 React Query/10-optimistic-updating/backend/package.json
+++ b/code/24 React Query/10-optimistic-updating/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/124](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/124)

To fix this issue, we will add rate-limiting middleware to the application using the `express-rate-limit` package. This middleware will restrict the number of requests that can be made to the `/events/:id` endpoint within a specified time window. Additionally, we will apply rate limiting to other endpoints that involve expensive file system operations, such as `/events`, `/events/images`, and `/events`.

**Steps:**
1. Install the `express-rate-limit` package to implement rate limiting.
2. Create a rate limiter instance with appropriate configuration (e.g., max requests per window and window duration).
3. Apply the rate-limiting middleware to affected routes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
