### PR TITLE
Potential fix for code scanning alert no. 122: Missing rate limiting

### DIFF
--- a/code/24 React Query/10-optimistic-updating/backend/app.js
+++ b/code/24 React Query/10-optimistic-updating/backend/app.js
@@ -2,11 +2,18 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
-
 app.use(bodyParser.json());
 app.use(express.static('public'));
+
+// Configure rate limiting: max 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+app.use(limiter);
 
 app.use((req, res, next) => {
   res.setHeader('Access-Control-Allow-Origin', '*');

--- a/code/24 React Query/10-optimistic-updating/backend/package.json
+++ b/code/24 React Query/10-optimistic-updating/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/122](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/122)

To address the issue, we will introduce rate limiting to the application using the `express-rate-limit` middleware. This middleware will limit the number of requests a client can make to the server within a specific time window. For this fix:

1. Install the `express-rate-limit` package, as it is a widely used library for rate limiting in Express applications.
2. Configure the middleware to set a maximum number of requests (e.g., 100 requests per 15 minutes) and apply it to all routes globally.
3. This setup will ensure that all route handlers, including the one flagged (`POST /events`), are protected against excessive requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
