### PR TITLE
Potential fix for code scanning alert no. 121: Missing rate limiting

### DIFF
--- a/code/24 React Query/10-optimistic-updating/backend/app.js
+++ b/code/24 React Query/10-optimistic-updating/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -55,7 +56,12 @@ app.get('/events/images', async (req, res) => {
   res.json({ images });
 });
 
-app.get('/events/:id', async (req, res) => {
+const eventLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+});
+
+app.get('/events/:id', eventLimiter, async (req, res) => {
   const { id } = req.params;
 
   const eventsFileContent = await fs.readFile('./data/events.json');


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/121](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/121)

To fix this issue, rate limiting should be implemented for the `/events/:id` route handler to limit the number of requests a client can make within a specific time frame. The `express-rate-limit` package is a popular choice for implementing rate limiting in Express applications.

**Detailed steps to fix the issue:**
1. Install the `express-rate-limit` package, which provides middleware for rate limiting.
2. Define a rate-limiting configuration, such as allowing a maximum of 100 requests per 15 minutes per client.
3. Apply the rate-limiting middleware to the `/events/:id` route handler.
4. Ensure other route handlers requiring rate limiting are addressed similarly if needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
