### PR TITLE
Potential fix for code scanning alert no. 120: Missing rate limiting

### DIFF
--- a/code/24 React Query/10-optimistic-updating/backend/app.js
+++ b/code/24 React Query/10-optimistic-updating/backend/app.js
@@ -48,7 +48,14 @@ app.get('/events', async (req, res) => {
   });
 });
 
-app.get('/events/images', async (req, res) => {
+import RateLimit from 'express-rate-limit';
+
+const imagesLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.get('/events/images', imagesLimiter, async (req, res) => {
   const imagesFileContent = await fs.readFile('./data/images.json');
   const images = JSON.parse(imagesFileContent);
 

--- a/code/24 React Query/10-optimistic-updating/backend/package.json
+++ b/code/24 React Query/10-optimistic-updating/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/120](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/120)

To address the lack of rate-limiting in the `/events/images` route, a rate-limiting middleware will be added using the `express-rate-limit` package. This middleware will restrict the number of requests that can be made to the route within a specified time window.

Steps:
1. Install the `express-rate-limit` package if not already installed.
2. Create a rate-limiting instance with appropriate configuration (e.g., limit requests to 100 per 15 minutes).
3. Apply this rate-limiting middleware specifically to the `/events/images` route.

This fix ensures that the route is protected against excessive request loads, improving the application's resilience to DoS attacks without altering its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
