### PR TITLE
Potential fix for code scanning alert no. 118: Missing rate limiting

### DIFF
--- a/code/24 React Query/09-disabling-automatic-refetching/backend/app.js
+++ b/code/24 React Query/09-disabling-automatic-refetching/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -149,7 +150,13 @@ app.put('/events/:id', async (req, res) => {
   }, 1000);
 });
 
-app.delete('/events/:id', async (req, res) => {
+const deleteEventLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // max 50 requests per windowMs
+  message: { message: 'Too many delete requests, please try again later.' },
+});
+
+app.delete('/events/:id', deleteEventLimiter, async (req, res) => {
   const { id } = req.params;
 
   const eventsFileContent = await fs.readFile('./data/events.json');

--- a/code/24 React Query/09-disabling-automatic-refetching/backend/package.json
+++ b/code/24 React Query/09-disabling-automatic-refetching/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/118](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/118)

To address the issue, we will introduce a rate-limiting middleware using the `express-rate-limit` package. This middleware will limit the number of requests that can be made to the `/events/:id` DELETE endpoint within a specified time window. This ensures that the server is protected against DoS attacks targeting this route.

Steps to implement the fix:
1. Install the `express-rate-limit` package.
2. Import the package in the file.
3. Define a rate-limiting middleware with appropriate configuration (e.g., maximum requests per minute).
4. Apply the middleware specifically to the `/events/:id` DELETE route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
