### PR TITLE
Potential fix for code scanning alert no. 115: Missing rate limiting

### DIFF
--- a/code/24 React Query/09-disabling-automatic-refetching/backend/app.js
+++ b/code/24 React Query/09-disabling-automatic-refetching/backend/app.js
@@ -64,7 +64,14 @@ app.get('/events/images', async (req, res) => {
   res.json({ images });
 });
 
-app.get('/events/:id', async (req, res) => {
+// Configure rate limiter: maximum of 20 requests per minute for the /events/:id route
+const eventsIdLimiter = RateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 20, // Limit each IP to 20 requests per windowMs
+  message: { message: 'Too many requests, please try again later.' },
+});
+
+app.get('/events/:id', eventsIdLimiter, async (req, res) => {
   const { id } = req.params;
 
   const eventsFileContent = await fs.readFile('./data/events.json');


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/115](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/115)

To address the issue, we will add a rate limiter specifically for the `/events/:id` route. This will limit the number of requests an IP can make to this endpoint within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file, to configure and apply the rate limiter.

Steps:
1. Define a new rate limiter for the `/events/:id` route, setting a reasonable limit (e.g., 20 requests per minute).
2. Apply the rate limiter middleware to the `/events/:id` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
