### PR TITLE
Potential fix for code scanning alert no. 112: Missing rate limiting

### DIFF
--- a/code/24 React Query/08-challenge-problem/backend/app.js
+++ b/code/24 React Query/08-challenge-problem/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -55,7 +56,13 @@ app.get('/events/images', async (req, res) => {
   res.json({ images });
 });
 
-app.get('/events/:id', async (req, res) => {
+const eventRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: 'Too many requests to /events/:id. Please try again later.',
+});
+
+app.get('/events/:id', eventRateLimiter, async (req, res) => {
   const { id } = req.params;
 
   const eventsFileContent = await fs.readFile('./data/events.json');

--- a/code/24 React Query/08-challenge-problem/backend/package.json
+++ b/code/24 React Query/08-challenge-problem/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/112](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/112)

To address the issue, we will apply a rate-limiting middleware to the Express application using the `express-rate-limit` package. This middleware will restrict the number of requests a client can make to the `/events/:id` endpoint within a specified time window. Specifically:

1. Install the `express-rate-limit` package to enable rate limiting.
2. Configure a rate limiter to allow a maximum of 100 requests per 15 minutes (or any appropriate threshold for the application's expected traffic).
3. Apply the rate limiter specifically to the `/events/:id` route to mitigate the risk of filesystem abuse on that endpoint.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
