### PR TITLE
Potential fix for code scanning alert no. 114: Missing rate limiting

### DIFF
--- a/code/24 React Query/09-disabling-automatic-refetching/backend/app.js
+++ b/code/24 React Query/09-disabling-automatic-refetching/backend/app.js
@@ -57,7 +57,14 @@ app.get('/events', async (req, res) => {
   });
 });
 
-app.get('/events/images', async (req, res) => {
+// Configure rate limiter: maximum of 20 requests per minute for the /events/images route
+const eventsImagesLimiter = RateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 20, // Limit each IP to 20 requests per windowMs
+  message: { message: 'Too many requests, please try again later.' },
+});
+
+app.get('/events/images', eventsImagesLimiter, async (req, res) => {
   const imagesFileContent = await fs.readFile('./data/images.json');
   const images = JSON.parse(imagesFileContent);
 


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/114](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/114)

To fix this issue, we need to add rate limiting to the `/events/images` route. The `express-rate-limit` package is already imported and used elsewhere in the code, so no new dependencies are required. We will configure a rate limiter specifically for this route, limiting requests to a reasonable number per minute (e.g., 20 requests per minute). Then, we will apply the limiter as middleware to the `/events/images` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
