### PR TITLE
Potential fix for code scanning alert no. 105: Missing rate limiting

### DIFF
--- a/code/24 React Query/07-acting-on-mutation-success-and-invalidating-queries/backend/app.js
+++ b/code/24 React Query/07-acting-on-mutation-success-and-invalidating-queries/backend/app.js
@@ -12,6 +12,12 @@ const deleteLimiter = RateLimit({
   message: { message: 'Too many delete requests, please try again later.' },
 });
 
+const putLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // Limit each IP to 50 requests per windowMs
+  message: { message: 'Too many update requests, please try again later.' },
+});
+
 app.use(bodyParser.json());
 app.use(express.static('public'));
 
@@ -116,7 +122,7 @@ app.post('/events', async (req, res) => {
   res.json({ event: newEvent });
 });
 
-app.put('/events/:id', async (req, res) => {
+app.put('/events/:id', putLimiter, async (req, res) => {
   const { id } = req.params;
   const { event } = req.body;
 


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/105](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/105)

To fix the issue, we need to apply rate limiting to the `PUT /events/:id` route. The existing `deleteLimiter` middleware is a good starting point, but we should create a separate rate limiter specifically for the `PUT` endpoint to ensure flexibility in configuring limits for different routes. The new rate limiter will specify a maximum number of requests per window (e.g., 50 requests per 15 minutes). 

Changes:
1. Define a new rate limiter (`putLimiter`) using the `express-rate-limit` middleware.
2. Apply this new limiter middleware to the `PUT /events/:id` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
