### PR TITLE
Potential fix for code scanning alert no. 100: Missing rate limiting

### DIFF
--- a/code/24 React Query/06-fetching-more-data-and-testing-mutation/backend/app.js
+++ b/code/24 React Query/06-fetching-more-data-and-testing-mutation/backend/app.js
@@ -2,12 +2,21 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
 
 app.use(bodyParser.json());
-app.use(express.static('public'));
+// Configure rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // 100 requests per windowMs
+});
 
+// Apply rate limiter to all requests
+app.use(limiter);
+
+app.use(express.static('public'));
 app.use((req, res, next) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader(

--- a/code/24 React Query/06-fetching-more-data-and-testing-mutation/backend/package.json
+++ b/code/24 React Query/06-fetching-more-data-and-testing-mutation/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/100](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/100)

To address the issue, we will integrate a rate-limiting middleware using the `express-rate-limit` package. This middleware will restrict the number of requests a client can make to the server within a specific time frame. We'll configure the rate limiter to allow a maximum of 100 requests per 15 minutes for all routes, including the `DELETE /events/:id` endpoint.

Steps:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package at the beginning of the file.
3. Configure the rate limiter with appropriate settings (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter middleware globally to all routes using `app.use`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
