### PR TITLE
Potential fix for code scanning alert no. 104: Missing rate limiting

### DIFF
--- a/code/24 React Query/07-acting-on-mutation-success-and-invalidating-queries/backend/app.js
+++ b/code/24 React Query/07-acting-on-mutation-success-and-invalidating-queries/backend/app.js
@@ -12,12 +12,17 @@ const deleteLimiter = RateLimit({
   message: { message: 'Too many delete requests, please try again later.' },
 });
 
+const postLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // Limit each IP to 50 requests per windowMs
+  message: { message: 'Too many create event requests, please try again later.' },
+});
+
 const putLimiter = RateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 50, // Limit each IP to 50 requests per windowMs
   message: { message: 'Too many update requests, please try again later.' },
 });
-
 app.use(bodyParser.json());
 app.use(express.static('public'));
 
@@ -87,7 +92,7 @@ app.get('/events/:id', async (req, res) => {
   }, 1000);
 });
 
-app.post('/events', async (req, res) => {
+app.post('/events', postLimiter, async (req, res) => {
   const { event } = req.body;
 
   if (!event) {


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/104](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/104)

To fix the issue, we will add rate-limiting middleware to the `POST /events` route using the `express-rate-limit` package, which is already imported in the code. This will allow us to limit the number of requests that clients can make to this route within a specified time window. Specifically, we will define a new rate limiter (e.g., `postLimiter`), configure it with appropriate limits (e.g., 50 requests per 15 minutes, similar to the existing rate limiters), and apply it to the `POST /events` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
