### PR TITLE
Potential fix for code scanning alert no. 94: Missing rate limiting

### DIFF
--- a/code/24 React Query/05-changing-data-with-mutations/backend/app.js
+++ b/code/24 React Query/05-changing-data-with-mutations/backend/app.js
@@ -2,8 +2,15 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+});
 
 app.use(bodyParser.json());
 app.use(express.static('public'));
@@ -149,7 +156,7 @@ app.put('/events/:id', async (req, res) => {
   }, 1000);
 });
 
-app.delete('/events/:id', async (req, res) => {
+app.delete('/events/:id', limiter, async (req, res) => {
   const { id } = req.params;
 
   const eventsFileContent = await fs.readFile('./data/events.json');

--- a/code/24 React Query/05-changing-data-with-mutations/backend/package.json
+++ b/code/24 React Query/05-changing-data-with-mutations/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/94](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/94)

To fix the issue, we will add rate limiting to the Express application using the `express-rate-limit` package. This package is a widely used library that helps limit the number of requests from a single IP address or client within a defined window of time. 

1. Install the `express-rate-limit` package to enable rate limiting.
2. Set up a rate limiter middleware with reasonable defaults (e.g., 100 requests per 15 minutes).
3. Apply the rate limiter middleware to all routes or specifically to routes that perform expensive file system operations.

We will define and configure the rate limiter in the `app.js` file and apply it to the `DELETE /events/:id` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
