### PR TITLE
Potential fix for code scanning alert no. 93: Missing rate limiting

### DIFF
--- a/code/24 React Query/05-changing-data-with-mutations/backend/app.js
+++ b/code/24 React Query/05-changing-data-with-mutations/backend/app.js
@@ -116,7 +116,7 @@ app.post('/events', async (req, res) => {
   res.json({ event: newEvent });
 });
 
-app.put('/events/:id', async (req, res) => {
+app.put('/events/:id', limiter, async (req, res) => {
   const { id } = req.params;
   const { event } = req.body;
 


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/93](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/93)

To fix the problem, rate limiting should be introduced to the `PUT /events/:id` route. This can be done by applying the existing `limiter` middleware, which is already defined and used elsewhere in the same file. The middleware limits each IP to a maximum of 100 requests per 15-minute window. This ensures that the route is protected from excessive requests.

The fix involves:
1. Adding the `limiter` middleware to the `PUT /events/:id` route.
2. No changes to the `limiter` configuration are required, as the same limits are suitable for this route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
