### PR TITLE
Potential fix for code scanning alert no. 88: Missing rate limiting

### DIFF
--- a/code/24 React Query/04-enabling-disabling-queries/backend/app.js
+++ b/code/24 React Query/04-enabling-disabling-queries/backend/app.js
@@ -2,11 +2,19 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
 app.use(bodyParser.json());
 app.use(express.static('public'));
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+app.use(limiter);
 
 app.use((req, res, next) => {
   res.setHeader('Access-Control-Allow-Origin', '*');

--- a/code/24 React Query/04-enabling-disabling-queries/backend/package.json
+++ b/code/24 React Query/04-enabling-disabling-queries/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/88](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/88)

To fix the issue, a rate-limiting middleware will be introduced to limit the number of requests a client can make to the server within a specific time window. The `express-rate-limit` library will be used for this purpose. This middleware will be applied globally to all routes in the application to ensure uniform protection against abuse.

Steps:
1. Install the `express-rate-limit` package in the project.
2. Import the package at the top of the file.
3. Configure a rate limiter with a sensible default (e.g., 100 requests per 15 minutes).
4. Use the rate limiter middleware globally in the Express app before defining the routes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
