### PR TITLE
Potential fix for code scanning alert no. 101: Missing rate limiting

### DIFF
--- a/code/24 React Query/07-acting-on-mutation-success-and-invalidating-queries/backend/app.js
+++ b/code/24 React Query/07-acting-on-mutation-success-and-invalidating-queries/backend/app.js
@@ -45,7 +45,13 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/events', async (req, res) => {
+const getEventsLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // Limit each IP to 50 requests per windowMs
+  message: { message: 'Too many requests for events, please try again later.' },
+});
+
+app.get('/events', getEventsLimiter, async (req, res) => {
   const { max, search } = req.query;
   const eventsFileContent = await fs.readFile('./data/events.json');
   let events = JSON.parse(eventsFileContent);


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/101](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/101)

To address the issue, we should apply a rate limiter to the `/events` route. This can be achieved by defining a new rate limiter (e.g., `getEventsLimiter`) using the `express-rate-limit` package, similar to the existing limiters in the code. The limiter will restrict the number of requests each client can make to the `/events` endpoint within a specified time window. The limiter should then be applied as middleware for the `/events` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
