### PR TITLE
Potential fix for code scanning alert no. 91: Missing rate limiting

### DIFF
--- a/code/24 React Query/05-changing-data-with-mutations/backend/app.js
+++ b/code/24 React Query/05-changing-data-with-mutations/backend/app.js
@@ -62,7 +62,12 @@ app.get('/events/images', async (req, res) => {
   res.json({ images });
 });
 
-app.get('/events/:id', async (req, res) => {
+const eventLimiter = RateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 50, // Limit each IP to 50 requests per windowMs
+});
+
+app.get('/events/:id', eventLimiter, async (req, res) => {
   const { id } = req.params;
 
   const eventsFileContent = await fs.readFile('./data/events.json');


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/91](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/91)

The best way to fix the problem is to explicitly apply the `express-rate-limit` rate-limiting middleware to the `/events/:id` route. This ensures that the route is protected even if the global limiter is not applied to all routes. 

Steps to fix:
1. Define a specific rate limiter for the `/events/:id` route.
2. Apply this rate limiter to the route using `app.use`.

Necessary changes:
- Add a new rate limiter configuration for the `/events/:id` endpoint.
- Apply the rate limiter directly to the route definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
