### PR TITLE
Potential fix for code scanning alert no. 64: Missing rate limiting

### DIFF
--- a/code/18 Practice Project - Food Order/13-managing-form-status-actions/backend/app.js
+++ b/code/18 Practice Project - Food Order/13-managing-form-status-actions/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -20,7 +21,12 @@ app.get('/meals', async (req, res) => {
   res.json(JSON.parse(meals));
 });
 
-app.post('/orders', async (req, res) => {
+const orderRateLimiter = RateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10, // Limit each IP to 10 requests per windowMs
+});
+
+app.post('/orders', orderRateLimiter, async (req, res) => {
   const orderData = req.body.order;
 
   await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/code/18 Practice Project - Food Order/13-managing-form-status-actions/backend/package.json
+++ b/code/18 Practice Project - Food Order/13-managing-form-status-actions/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/64](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/64)

#### General Fix:
Introduce rate-limiting middleware to cap the number of requests allowed per timeframe. This ensures that the `/orders` endpoint cannot be abused to overwhelm the server.

#### Best Way to Fix:
1. Install the `express-rate-limit` package to provide rate-limiting functionality.
2. Apply the rate-limiting middleware specifically to the `/orders` endpoint.
3. Configure the middleware to allow a reasonable number of requests per given time window (e.g., 10 requests per minute).

#### Specific Changes Needed:
1. Import the `express-rate-limit` package at the top of the file.
2. Define a rate limiter using `RateLimit` with appropriate options (e.g., `windowMs` and `max`).
3. Apply the rate limiter middleware to the `/orders` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
