### PR TITLE
Potential fix for code scanning alert no. 89: Missing rate limiting

### DIFF
--- a/code/24 React Query/05-changing-data-with-mutations/backend/app.js
+++ b/code/24 React Query/05-changing-data-with-mutations/backend/app.js
@@ -28,7 +28,12 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/events', async (req, res) => {
+const eventsLimiter = RateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 50, // Limit each IP to 50 requests per windowMs
+});
+
+app.get('/events', eventsLimiter, async (req, res) => {
   const { max, search } = req.query;
   const eventsFileContent = await fs.readFile('./data/events.json');
   let events = JSON.parse(eventsFileContent);


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/89](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/89)

To fix the issue, we will apply rate-limiting middleware to the `/events` route. We'll reuse the existing `express-rate-limit` package already imported in the code. Specifically, we'll create a new rate limiter instance tailored to the `/events` route. For consistency with other parts of the code, we'll set a limit of 50 requests per 10 minutes (similar to the `/events/images` and `/events/:id` routes). This ensures that the route is adequately protected without disrupting normal user activity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
