### PR TITLE
Potential fix for code scanning alert no. 62: Missing rate limiting

### DIFF
--- a/code/18 Practice Project - Food Order/12-finishing-touches/backend/app.js
+++ b/code/18 Practice Project - Food Order/12-finishing-touches/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -20,7 +21,14 @@ app.get('/meals', async (req, res) => {
   res.json(JSON.parse(meals));
 });
 
-app.post('/orders', async (req, res) => {
+// Configure rate limiter: maximum of 100 requests per 15 minutes
+const orderRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { message: 'Too many requests, please try again later.' },
+});
+
+app.post('/orders', orderRateLimiter, async (req, res) => {
   const orderData = req.body.order;
 
   if (orderData === null || orderData.items === null || orderData.items.length === 0) {

--- a/code/18 Practice Project - Food Order/12-finishing-touches/backend/package.json
+++ b/code/18 Practice Project - Food Order/12-finishing-touches/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/62](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/62)

To fix the issue, we will add rate-limiting functionality to the Express application using the `express-rate-limit` package. This middleware will limit the number of requests a client can make to the `/orders` endpoint within a specified time window. The `express-rate-limit` package is well-suited for this purpose and widely used in the Node.js ecosystem.

Specifically, we will:
1. Install the `express-rate-limit` package as a dependency.
2. Configure a rate-limiting middleware with a reasonable limit (e.g., 100 requests per 15 minutes).
3. Apply the rate limiter to the `/orders` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
