### PR TITLE
Potential fix for code scanning alert no. 67: Missing rate limiting

### DIFF
--- a/code/24 React Query/01-starting-project/backend/app.js
+++ b/code/24 React Query/01-starting-project/backend/app.js
@@ -56,7 +56,12 @@ app.get('/events/images', async (req, res) => {
   res.json({ images });
 });
 
-app.get('/events/:id', async (req, res) => {
+const getEventLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per window
+});
+
+app.get('/events/:id', getEventLimiter, async (req, res) => {
   const { id } = req.params;
 
   const eventsFileContent = await fs.readFile('./data/events.json');


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/67](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/67)

To address the missing rate limiting on the `GET /events/:id` endpoint:
1. Use the `express-rate-limit` package, which is already imported as `RateLimit`.
2. Define a rate limiter specific to this endpoint. For example, allow a maximum of 100 requests per 15 minutes.
3. Apply the rate limiter middleware to the `GET /events/:id` route.

This fix ensures that the number of requests to the `GET /events/:id` endpoint is controlled, reducing the risk of abuse or server overload.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
