### PR TITLE
Potential fix for code scanning alert no. 58: Missing rate limiting

### DIFF
--- a/code/18 Practice Project - Food Order/10-sending-a-post-request/backend/app.js
+++ b/code/18 Practice Project - Food Order/10-sending-a-post-request/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -20,7 +21,12 @@ app.get('/meals', async (req, res) => {
   res.json(JSON.parse(meals));
 });
 
-app.post('/orders', async (req, res) => {
+const orderLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.post('/orders', orderLimiter, async (req, res) => {
   const orderData = req.body.order;
 
   if (orderData === null || orderData.items === null || orderData.items.length === 0) {

--- a/code/18 Practice Project - Food Order/10-sending-a-post-request/backend/package.json
+++ b/code/18 Practice Project - Food Order/10-sending-a-post-request/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/58](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/58)

To address the issue, we will use the `express-rate-limit` package to implement rate limiting for the `app.post('/orders')` route. This package allows us to define a maximum number of requests that can be made within a specified time window. For example, we can limit the endpoint to accept a maximum of 100 requests per 15 minutes.

**Steps to fix:**
1. Install the `express-rate-limit` package.
2. Import the package in the file.
3. Create a rate-limiting middleware with appropriate configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate-limiting middleware specifically to the `app.post('/orders')` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
