### PR TITLE
Potential fix for code scanning alert no. 56: Missing rate limiting

### DIFF
--- a/code/18 Practice Project - Food Order/09-handling-form-submission/backend/app.js
+++ b/code/18 Practice Project - Food Order/09-handling-form-submission/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -20,7 +21,13 @@ app.get('/meals', async (req, res) => {
   res.json(JSON.parse(meals));
 });
 
-app.post('/orders', async (req, res) => {
+const ordersRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: { message: 'Too many orders created from this IP, please try again later.' },
+});
+
+app.post('/orders', ordersRateLimiter, async (req, res) => {
   const orderData = req.body.order;
 
   if (orderData === null || orderData.items === null || orderData.items.length === 0) {

--- a/code/18 Practice Project - Food Order/09-handling-form-submission/backend/package.json
+++ b/code/18 Practice Project - Food Order/09-handling-form-submission/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/56](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/56)

To address the issue, the `express-rate-limit` middleware should be added to the application to limit the rate of incoming requests to the `/orders` endpoint. This will prevent abuse by restricting the number of requests a client can make within a specific time frame. A rate-limiting configuration should be applied specifically to the `/orders` route, leaving other routes unaffected.

Steps to implement the fix:
1. Install and import the `express-rate-limit` library.
2. Configure a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
3. Apply the rate limiter middleware to the `/orders` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
