### PR TITLE
Potential fix for code scanning alert no. 52: Missing rate limiting

### DIFF
--- a/code/18 Practice Project - Food Order/07-adding-reusable-modal/backend/app.js
+++ b/code/18 Practice Project - Food Order/07-adding-reusable-modal/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -20,7 +21,12 @@ app.get('/meals', async (req, res) => {
   res.json(JSON.parse(meals));
 });
 
-app.post('/orders', async (req, res) => {
+const orderRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+app.post('/orders', orderRateLimiter, async (req, res) => {
   const orderData = req.body.order;
 
   if (orderData === null || orderData.items === null || orderData.items.length === 0) {

--- a/code/18 Practice Project - Food Order/07-adding-reusable-modal/backend/package.json
+++ b/code/18 Practice Project - Food Order/07-adding-reusable-modal/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/52](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/52)

To fix the issue, we should add a rate-limiting middleware using a well-known library like `express-rate-limit`. This middleware will limit the number of requests a client can make to the `/orders` endpoint within a specified time window. For this particular use case, we can configure a rate limit of, for example, 100 requests per 15 minutes, which is a common default.

The changes involve:
1. Importing the `express-rate-limit` package.
2. Setting up a rate limiter instance with appropriate configuration.
3. Applying the rate limiter specifically to the `/orders` route to ensure it is protected without affecting other routes unnecessarily.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
