### PR TITLE
Potential fix for code scanning alert no. 50: Missing rate limiting

### DIFF
--- a/code/18 Practice Project - Food Order/06-finishing-using-cart-context/backend/app.js
+++ b/code/18 Practice Project - Food Order/06-finishing-using-cart-context/backend/app.js
@@ -2,9 +2,9 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
-
 app.use(bodyParser.json());
 app.use(express.static('public'));
 
@@ -20,7 +20,12 @@ app.get('/meals', async (req, res) => {
   res.json(JSON.parse(meals));
 });
 
-app.post('/orders', async (req, res) => {
+const ordersRateLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.post('/orders', ordersRateLimiter, async (req, res) => {
   const orderData = req.body.order;
 
   if (orderData === null || orderData.items === null || orderData.items.length === 0) {

--- a/code/18 Practice Project - Food Order/06-finishing-using-cart-context/backend/package.json
+++ b/code/18 Practice Project - Food Order/06-finishing-using-cart-context/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/50](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/50)

To address the issue, we will incorporate a rate-limiting middleware using the `express-rate-limit` package. This middleware will limit the number of requests a client can make to the `/orders` endpoint within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the package at the top of the file.
3. Define a rate limiter with appropriate configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to the `/orders` route.

These changes will mitigate the risk of DoS attacks by restricting the frequency of requests to the sensitive route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
