### PR TITLE
Potential fix for code scanning alert no. 43: Missing rate limiting

### DIFF
--- a/code/18 Practice Project - Food Order/03-fetching-meals-data/backend/app.js
+++ b/code/18 Practice Project - Food Order/03-fetching-meals-data/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -15,7 +16,12 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/meals', async (req, res) => {
+const mealsLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.get('/meals', mealsLimiter, async (req, res) => {
   const meals = await fs.readFile('./data/available-meals.json', 'utf8');
   res.json(JSON.parse(meals));
 });

--- a/code/18 Practice Project - Food Order/03-fetching-meals-data/backend/package.json
+++ b/code/18 Practice Project - Food Order/03-fetching-meals-data/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/43](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/43)

To fix the issue, we will use the `express-rate-limit` package, a widely used middleware for rate limiting in Express applications. The fix involves:

1. Installing the `express-rate-limit` package to implement rate limiting.
2. Setting up a rate limiter to restrict the number of requests per client within a specified time window.
3. Applying the rate limiter middleware to the `/meals` endpoint to ensure its file system access is protected.

The rate limiter will restrict excessive requests to this endpoint, preventing potential denial-of-service attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
