### PR TITLE
Potential fix for code scanning alert no. 42: Missing rate limiting

### DIFF
--- a/code/18 Practice Project - Food Order/02-planning-and-first-cmp/backend/app.js
+++ b/code/18 Practice Project - Food Order/02-planning-and-first-cmp/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -20,7 +21,7 @@ app.get('/meals', async (req, res) => {
   res.json(JSON.parse(meals));
 });
 
-app.post('/orders', async (req, res) => {
+app.post('/orders', orderRateLimiter, async (req, res) => {
   const orderData = req.body.order;
 
   if (orderData === null || orderData.items === null || orderData.items.length === 0) {

--- a/code/18 Practice Project - Food Order/02-planning-and-first-cmp/backend/package.json
+++ b/code/18 Practice Project - Food Order/02-planning-and-first-cmp/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/42](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/42)

To address the issue, we will introduce rate limiting to the `/orders` endpoint using the `express-rate-limit` package. This middleware enforces limits on the number of requests a client can make within a specified time window. For this fix:
1. Install the `express-rate-limit` package.
2. Create a rate limiter with appropriate configuration (e.g., 100 requests per 15 minutes).
3. Apply the rate limiter specifically to the `/orders` route.

This fix ensures that the application can handle bursts of traffic gracefully while mitigating DoS risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
