### PR TITLE
Potential fix for code scanning alert no. 40: Missing rate limiting

### DIFF
--- a/code/18 Practice Project - Food Order/01-starting-project/backend/app.js
+++ b/code/18 Practice Project - Food Order/01-starting-project/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -20,7 +21,13 @@ app.get('/meals', async (req, res) => {
   res.json(JSON.parse(meals));
 });
 
-app.post('/orders', async (req, res) => {
+const ordersRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { message: 'Too many requests, please try again later.' },
+});
+
+app.post('/orders', ordersRateLimiter, async (req, res) => {
   const orderData = req.body.order;
 
   if (orderData === null || orderData.items === null || orderData.items.length === 0) {

--- a/code/18 Practice Project - Food Order/01-starting-project/backend/package.json
+++ b/code/18 Practice Project - Food Order/01-starting-project/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/40](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/40)

To address the issue, we should add a rate-limiting middleware using the popular `express-rate-limit` package. This middleware will restrict the number of requests a client can make to the `/orders` route within a specific time window. Here's how to fix the problem:

1. Install the `express-rate-limit` package if it is not already installed.
2. Import `express-rate-limit` at the top of the file.
3. Configure the rate limiter with appropriate settings, such as a maximum of 100 requests per 15 minutes.
4. Apply the rate limiter specifically to the `/orders` route to limit access to this endpoint.

This ensures that the route is protected from being abused while keeping other routes unaffected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
