### PR TITLE
Potential fix for code scanning alert no. 38: Missing rate limiting

### DIFF
--- a/code/16 Custom Hooks/03-finished/backend/app.js
+++ b/code/16 Custom Hooks/03-finished/backend/app.js
@@ -2,8 +2,15 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
+
+const userPlacesLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+  message: { message: 'Too many requests, please try again later.' },
+});
 
 app.use(express.static('images'));
 app.use(bodyParser.json());
@@ -34,7 +41,7 @@ app.get('/user-places', async (req, res) => {
   res.status(200).json({ places });
 });
 
-app.put('/user-places', async (req, res) => {
+app.put('/user-places', userPlacesLimiter, async (req, res) => {
   const places = req.body.places;
 
   await fs.writeFile('./data/user-places.json', JSON.stringify(places));

--- a/code/16 Custom Hooks/03-finished/backend/package.json
+++ b/code/16 Custom Hooks/03-finished/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/38](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/38)

To fix the issue, we will add rate limiting to the `app.put('/user-places')` route handler using the `express-rate-limit` package. This middleware will restrict the number of requests that can be made to the endpoint within a specified time window. The fix involves:

1. Installing the `express-rate-limit` package.
2. Importing the package into the file.
3. Configuring a rate limiter with appropriate settings (e.g., maximum requests per minute).
4. Applying the rate limiter specifically to the `/user-places` route.

This approach ensures that the `/user-places` endpoint is protected from abuse without affecting other parts of the application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
