### PR TITLE
Potential fix for code scanning alert no. 36: Missing rate limiting

### DIFF
--- a/code/16 Custom Hooks/03-finished/backend/app.js
+++ b/code/16 Custom Hooks/03-finished/backend/app.js
@@ -25,7 +25,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/places', async (req, res) => {
+app.get('/places', userPlacesLimiter, async (req, res) => {
   const fileContent = await fs.readFile('./data/places.json');
 
   const placesData = JSON.parse(fileContent);


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/36](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/36)

To fix the issue, we need to apply a rate limiter to the `/places` endpoint. We can reuse the existing `RateLimit` middleware configuration (`userPlacesLimiter`) since it is already defined for similar endpoints (`/user-places` and `/user-places (PUT)`). This will ensure that all file system operations are protected against excessive requests.

Steps:
1. Modify the `/places` route handler to include the `userPlacesLimiter` middleware.
2. Verify that the `userPlacesLimiter` configuration is appropriate for the `/places` endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
