### PR TITLE
Potential fix for code scanning alert no. 32: Missing rate limiting

### DIFF
--- a/code/16 Custom Hooks/01-starting-project/backend/app.js
+++ b/code/16 Custom Hooks/01-starting-project/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -34,7 +35,12 @@ app.get('/user-places', async (req, res) => {
   res.status(200).json({ places });
 });
 
-app.put('/user-places', async (req, res) => {
+const userPlacesLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.put('/user-places', userPlacesLimiter, async (req, res) => {
   const places = req.body.places;
 
   await fs.writeFile('./data/user-places.json', JSON.stringify(places));

--- a/code/16 Custom Hooks/01-starting-project/backend/package.json
+++ b/code/16 Custom Hooks/01-starting-project/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/32](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/32)

To address the issue, we will add rate limiting using the `express-rate-limit` package. This middleware will restrict the number of accepted requests within a given time window, reducing the risk of abuse. Specifically, we will:

1. Install and import the `express-rate-limit` package.
2. Configure a rate limiter with appropriate limits (e.g., max 100 requests in a 15-minute window).
3. Apply the rate limiter middleware to the `/user-places` route to limit its access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
