### PR TITLE
Potential fix for code scanning alert no. 31: Missing rate limiting

### DIFF
--- a/code/16 Custom Hooks/01-starting-project/backend/app.js
+++ b/code/16 Custom Hooks/01-starting-project/backend/app.js
@@ -27,7 +27,12 @@ app.get('/places', async (req, res) => {
   res.status(200).json({ places: placesData });
 });
 
-app.get('/user-places', async (req, res) => {
+const userPlacesGetLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.get('/user-places', userPlacesGetLimiter, async (req, res) => {
   const fileContent = await fs.readFile('./data/user-places.json');
 
   const places = JSON.parse(fileContent);


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/31](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/31)

To fix the issue, we will add rate limiting to the `/user-places` GET route using the `express-rate-limit` package already imported in the file. This is the same approach used for the `/user-places` PUT route. We'll configure a rate limiter with a reasonable limit (e.g., 100 requests per 15 minutes) and apply it to the `/user-places` GET route.

No additional dependencies are needed since `express-rate-limit` is already imported. The rate limiter configuration should be consistent with the existing `/user-places` PUT route limiter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
