### PR TITLE
Potential fix for code scanning alert no. 29: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/08-practice-finished/backend/app.js
+++ b/code/15 HTTP Requests/08-practice-finished/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -34,7 +35,7 @@ app.get('/user-places', async (req, res) => {
   res.status(200).json({ places });
 });
 
-app.put('/user-places', async (req, res) => {
+app.put('/user-places', userPlacesLimiter, async (req, res) => {
   const places = req.body.places;
 
   await fs.writeFile('./data/user-places.json', JSON.stringify(places));

--- a/code/15 HTTP Requests/08-practice-finished/backend/package.json
+++ b/code/15 HTTP Requests/08-practice-finished/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/29](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/29)

To address the issue, we will implement rate limiting to prevent excessive requests to the `/user-places` endpoint. We will use the `express-rate-limit` package to enforce a maximum number of requests within a time window. Specifically:
1. Install and import the `express-rate-limit` package.
2. Create a rate limiter middleware with reasonable settings (e.g., max 100 requests per 15 minutes).
3. Apply the rate limiter middleware to the `/user-places` route handler.

This approach ensures requests to the route are throttled, mitigating the risk of overloading the server due to excessive I/O operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
