### PR TITLE
Potential fix for code scanning alert no. 23: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/06-optimistic-updating/backend/app.js
+++ b/code/15 HTTP Requests/06-optimistic-updating/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -34,7 +35,12 @@ app.get('/user-places', async (req, res) => {
   res.status(200).json({ places });
 });
 
-app.put('/user-places', async (req, res) => {
+const userPlacesLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.put('/user-places', userPlacesLimiter, async (req, res) => {
   const places = req.body.places;
 
   await fs.writeFile('./data/user-places.json', JSON.stringify(places));

--- a/code/15 HTTP Requests/06-optimistic-updating/backend/package.json
+++ b/code/15 HTTP Requests/06-optimistic-updating/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/23](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/23)

To address the issue, we will use the `express-rate-limit` package to apply rate limiting to the `app.put('/user-places')` route. This middleware will restrict the number of requests that can be made to this endpoint within a specified time window. For example, we can limit the endpoint to accept a maximum of 100 requests per 15 minutes.

**Steps to fix:**
1. Install the `express-rate-limit` package if not already installed.
2. Import the `express-rate-limit` package in the file.
3. Create a rate-limiting middleware with appropriate configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate-limiting middleware specifically to the `app.put('/user-places')` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
