### PR TITLE
Potential fix for code scanning alert no. 27: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/08-practice-finished/backend/app.js
+++ b/code/15 HTTP Requests/08-practice-finished/backend/app.js
@@ -19,7 +19,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/places', async (req, res) => {
+app.get('/places', placesLimiter, async (req, res) => {
   const fileContent = await fs.readFile('./data/places.json');
 
   const placesData = JSON.parse(fileContent);
@@ -33,6 +33,12 @@ app.get('/user-places', userPlacesLimiter, async (req, res) => {
   const places = JSON.parse(fileContent);
 
   res.status(200).json({ places });
+});
+
+const placesLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // max 50 requests per windowMs
+  message: { message: 'Too many requests to /places, please try again later.' },
 });
 
 const userPlacesLimiter = rateLimit({


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/27](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/27)

To fix the problem, we should apply a rate-limiting middleware to the `/places` route, similar to what has been done for the `/user-places` and `/user-places` `PUT` routes. We will reuse the `rateLimit` module to define a new rate-limiting policy specifically for the `/places` route. This policy will limit the number of requests that can be made to this endpoint within a specified time window. The fix will involve creating a new rate limiter instance and attaching it to the `/places` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
