### PR TITLE
Potential fix for code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/07-deleting/backend/app.js
+++ b/code/15 HTTP Requests/07-deleting/backend/app.js
@@ -19,7 +19,12 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/places', async (req, res) => {
+const placesLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+app.get('/places', placesLimiter, async (req, res) => {
   const fileContent = await fs.readFile('./data/places.json');
 
   const placesData = JSON.parse(fileContent);


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/24](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/24)

To fix the issue, we will add a rate-limiting middleware to the `/places` endpoint. This middleware will limit the number of requests an IP can make to this endpoint within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file, to implement this functionality.

Specifically:
1. Define a rate limiter for the `/places` endpoint, similar to the existing limiters for `/user-places` and `/user-places` PUT requests.
2. Apply the rate limiter to the `/places` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
