### PR TITLE
Potential fix for code scanning alert no. 21: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/06-optimistic-updating/backend/app.js
+++ b/code/15 HTTP Requests/06-optimistic-updating/backend/app.js
@@ -19,7 +19,12 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/places', async (req, res) => {
+const placesGetLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.get('/places', placesGetLimiter, async (req, res) => {
   const fileContent = await fs.readFile('./data/places.json');
 
   const placesData = JSON.parse(fileContent);


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/21](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/21)

To fix the issue, we will apply rate limiting to the `/places` route using the `express-rate-limit` package, which is already imported in the file. Specifically, we will create a rate-limiting middleware with a configuration similar to the one already used for other routes (e.g., `/user-places` and `/user-places` PUT). The limiter will restrict the number of requests to a maximum of 100 requests per 15 minutes.

We will define a new rate limiter middleware for the `/places` route and apply it in the route definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
