### PR TITLE
Potential fix for code scanning alert no. 20: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/05-sending-data/backend/app.js
+++ b/code/15 HTTP Requests/05-sending-data/backend/app.js
@@ -2,9 +2,15 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
-
+import RateLimit from 'express-rate-limit';
 const app = express();
 
+// Rate limiter: Maximum of 100 requests per 15 minutes
+const userPlacesLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: { message: 'Too many requests, please try again later.' },
+});
 app.use(express.static('images'));
 app.use(bodyParser.json());
 
@@ -34,7 +40,7 @@ app.get('/user-places', async (req, res) => {
   res.status(200).json({ places });
 });
 
-app.put('/user-places', async (req, res) => {
+app.put('/user-places', userPlacesLimiter, async (req, res) => {
   const places = req.body.places;
 
   await fs.writeFile('./data/user-places.json', JSON.stringify(places));

--- a/code/15 HTTP Requests/05-sending-data/backend/package.json
+++ b/code/15 HTTP Requests/05-sending-data/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/20](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/20)

To address the issue, we will integrate a rate-limiting middleware using the `express-rate-limit` package. This will enforce a limit on how many requests each client can make to the `/user-places` endpoint within a specified time window. This approach ensures that the server remains resilient against denial-of-service attacks while allowing legitimate users to access the endpoint without disruption.

Steps:
1. Install the `express-rate-limit` package.
2. Import the package in the file.
3. Configure a rate-limiter instance (e.g., allowing a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter specifically to the `/user-places` endpoint.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
