### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/04-extracting-code/backend/app.js
+++ b/code/15 HTTP Requests/04-extracting-code/backend/app.js
@@ -2,9 +2,8 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
-
+import rateLimit from 'express-rate-limit';
 const app = express();
-
 app.use(express.static('images'));
 app.use(bodyParser.json());
 
@@ -34,7 +33,7 @@ app.get('/user-places', async (req, res) => {
   res.status(200).json({ places });
 });
 
-app.put('/user-places', async (req, res) => {
+app.put('/user-places', userPlacesLimiter, async (req, res) => {
   const places = req.body.places;
 
   await fs.writeFile('./data/user-places.json', JSON.stringify(places));

--- a/code/15 HTTP Requests/04-extracting-code/backend/package.json
+++ b/code/15 HTTP Requests/04-extracting-code/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/17](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/17)

To fix the issue, we will add rate limiting to the `PUT /user-places` route using the `express-rate-limit` package. This package allows us to configure a rate limiter that limits the number of requests a client can make to the endpoint within a specified time window. Specifically:

1. Install and import the `express-rate-limit` package.
2. Configure a rate limiter, e.g., allowing a maximum of 10 requests per minute for the `PUT /user-places` route.
3. Apply the rate limiter as middleware to the `PUT /user-places` route.

This fix ensures that excessive requests are rejected, mitigating the risk of DoS attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
