### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/03-handling-errors/backend/app.js
+++ b/code/15 HTTP Requests/03-handling-errors/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -26,7 +27,13 @@ app.get('/places', async (req, res) => {
   res.status(200).json({ places: placesData });
 });
 
-app.get('/user-places', async (req, res) => {
+const userPlacesLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+app.get('/user-places', userPlacesLimiter, async (req, res) => {
   const fileContent = await fs.readFile('./data/user-places.json');
 
   const places = JSON.parse(fileContent);

--- a/code/15 HTTP Requests/03-handling-errors/backend/package.json
+++ b/code/15 HTTP Requests/03-handling-errors/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/13](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/13)

To fix the issue, we will introduce rate limiting middleware using the popular `express-rate-limit` package. This middleware will restrict the number of requests that can be made to the `/user-places` endpoint within a specified time window. Specifically, we will:
1. Install the `express-rate-limit` package.
2. Import the package in the file.
3. Create a rate limiter configuration allowing, for example, 100 requests per 15 minutes (adjustable as needed).
4. Apply this rate limiter to the `/user-places` route.

The fix ensures that the endpoint cannot be abused by excessive requests, safeguarding the application from potential DoS attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
