### PR TITLE
Potential fix for code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/02-using-async-await/backend/app.js
+++ b/code/15 HTTP Requests/02-using-async-await/backend/app.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 
 import bodyParser from 'body-parser';
 import express from 'express';
+import RateLimit from 'express-rate-limit';
 
 const app = express();
 
@@ -34,7 +35,12 @@ app.get('/user-places', async (req, res) => {
   res.status(200).json({ places });
 });
 
-app.put('/user-places', async (req, res) => {
+const userPlacesLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.put('/user-places', userPlacesLimiter, async (req, res) => {
   const places = req.body.places;
 
   await fs.writeFile('./data/user-places.json', JSON.stringify(places));

--- a/code/15 HTTP Requests/02-using-async-await/backend/package.json
+++ b/code/15 HTTP Requests/02-using-async-await/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/11](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/11)

To address the issue, we will use the `express-rate-limit` package to implement rate limiting for the affected route (`PUT /user-places`). This package allows us to define a maximum number of requests within a specified time window. For example, we can limit the route to accept a maximum of 100 requests every 15 minutes.

Steps to fix:
1. Install the `express-rate-limit` package.
2. Import the package in the file.
3. Create a rate-limiting middleware with appropriate configuration (e.g., 100 requests per 15 minutes).
4. Apply the middleware specifically to the `PUT /user-places` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
