### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/code/15 HTTP Requests/02-using-async-await/backend/app.js
+++ b/code/15 HTTP Requests/02-using-async-await/backend/app.js
@@ -27,7 +27,12 @@ app.get('/places', async (req, res) => {
   res.status(200).json({ places: placesData });
 });
 
-app.get('/user-places', async (req, res) => {
+const userPlacesGetLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+app.get('/user-places', userPlacesGetLimiter, async (req, res) => {
   const fileContent = await fs.readFile('./data/user-places.json');
 
   const places = JSON.parse(fileContent);


### PR DESCRIPTION
Potential fix for [https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/10](https://github.com/HelenDrug/react-complete-guide-course-resources/security/code-scanning/10)

To fix the problem, rate limiting should be applied to the `/user-places` route handler. The `express-rate-limit` middleware, which is already imported as `RateLimit`, can be used to enforce rate limiting for this endpoint. A rate limiter instance should be created specifically for this route, with appropriate configurations for the request rate (e.g., maximum of 100 requests within a 15-minute window). This rate limiter should then be applied to the `app.get('/user-places')` handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
